### PR TITLE
refactored makefile

### DIFF
--- a/Core/makefile
+++ b/Core/makefile
@@ -1,8 +1,26 @@
 CPPC=clang++
 FLAGS= -std=c++11 -I ./include
-SRC=src/multiDimRot/polytope/*.cpp src/multiDimRot/math/*.cpp src/multiDimRot/*.cpp src/*.cpp
+
+SRC=$(shell find -name "*.cpp")
+OBJC=$(SRC:./src/%.cpp=./bin/%.o)
+
 LIBS = -lGL -lsfml-system -lsfml-window -lsfml-graphics -lGLEW -lboost_system -lboost_thread
 
-MultiDimRot2.0: ${SRC}
-	${CPPC} -o MultiDimRot2.0 ${SRC} ${FLAGS} ${LIBS} 
+MultiDimRot2.0: ${OBJC}
+	@echo linking
+	${CPPC} -o MultiDimRot2.0 ${OBJC} ${FLAGS} ${LIBS} 
+
 all: MultiDimRot2.0
+
+bin/%.o: src/%.cpp
+	@echo
+	@echo building $@
+	mkdir -p ${dir $@} 
+	${CPPC} ${FLAGS} -c -o $@ $<
+	@echo
+
+clean:
+	rm -f MultiDimRot2.0
+	rm -rf bin
+
+.PHONY: clean


### PR DESCRIPTION
refactored makefile and made it being generic

#### Following changes:
* with $(shell find -name "*.cpp") you call the shell function find, that gives you all files, that ends with .cpp.
* with $(SRC:./src/%.cpp=./bin/%.o) you create the names of the object files.
* bin/%.o: src/%.cpp are implicit rules declarations:
* $@ describe the the left side of the rule
* $< describe the corresponding dependency

